### PR TITLE
HW-21. Kubernetes-2

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,10 @@
 extends: default
 
+ignore: |
+    *
+    !*.yaml
+    !*.yml
+
 rules:
   braces:
     max-spaces-inside: 1

--- a/kubernetes/reddit/comment-deployment.yml
+++ b/kubernetes/reddit/comment-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: comment-deployment
+  name: comment
+  labels:
+    app: reddit
+    component: comment
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: comment
+      app: reddit
+      component: comment
   template:
     metadata:
       name: comment
       labels:
-        app: comment
+        app: reddit
+        component: comment
     spec:
       containers:
         - image: yogsottot/comment
           name: comment
+          env:
+            - name: COMMENT_DATABASE_HOST
+              value: comment-db

--- a/kubernetes/reddit/comment-mongodb-service.yml
+++ b/kubernetes/reddit/comment-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-db
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    comment-db: "true"

--- a/kubernetes/reddit/comment-service.yml
+++ b/kubernetes/reddit/comment-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment
+  labels:
+    app: reddit
+    component: comment
+spec:
+  ports:
+    - port: 9292
+      protocol: TCP
+      targetPort: 9292
+  selector:
+    app: reddit
+    component: comment

--- a/kubernetes/reddit/dashboard.yml
+++ b/kubernetes/reddit/dashboard.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-dashboard
+    namespace: kube-system

--- a/kubernetes/reddit/dev-namespace.yml
+++ b/kubernetes/reddit/dev-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -2,18 +2,33 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: mongo-deployment
+  name: mongo
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+    post-db: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mongo
+      app: reddit
+      component: mongo
   template:
     metadata:
       name: mongo
       labels:
-        app: mongo
+        app: reddit
+        component: mongo
+        comment-db: "true"
+        post-db: "true"
     spec:
       containers:
-        - image: mongo
+        - image: mongo:3.2
           name: mongo
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+      volumes:
+        - name: mongo-persistent-storage
+          emptyDir: {}

--- a/kubernetes/reddit/mongodb-service.yml
+++ b/kubernetes/reddit/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit/post-deployment.yml
+++ b/kubernetes/reddit/post-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: post-deployment
+  name: post
+  labels:
+    app: reddit
+    component: post
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: post
+      app: reddit
+      component: post
   template:
     metadata:
       name: post
       labels:
-        app: post
+        app: reddit
+        component: post
     spec:
       containers:
         - image: yogsottot/post
           name: post
+          env:
+            - name: POST_DATABASE_HOST
+              value: post-db

--- a/kubernetes/reddit/post-mongodb-service.yml
+++ b/kubernetes/reddit/post-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-db
+  labels:
+    app: reddit
+    component: mongo
+    post-db: "true"
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    post-db: "true"

--- a/kubernetes/reddit/post-service.yml
+++ b/kubernetes/reddit/post-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post
+  labels:
+    app: reddit
+    component: post
+spec:
+  ports:
+    - port: 5000
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: reddit
+    component: post

--- a/kubernetes/reddit/ui-deployment.yml
+++ b/kubernetes/reddit/ui-deployment.yml
@@ -2,18 +2,28 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: ui-deployment
+  name: ui
+  labels:
+    app: reddit
+    component: ui
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: ui
+      app: reddit
+      component: ui
   template:
     metadata:
-      name: ui
+      name: ui-pod
       labels:
-        app: ui
+        app: reddit
+        component: ui
     spec:
       containers:
         - image: yogsottot/ui
           name: ui
+          env:
+            - name: ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  type: NodePort
+  ports:
+    # - nodePort: 32092
+    - port: 9292
+      protocol: TCP
+      targetPort: 9292
+  selector:
+    app: reddit
+    component: ui

--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,0 +1,70 @@
+provider "google" {
+  version = "1.20.0"
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "${var.cluster_name}"
+  zone               = "${var.zone}"
+  initial_node_count = "${var.count_gke_node}"
+
+  # Setting an empty username and password explicitly disables basic auth
+  master_auth {
+    username = ""
+    password = ""
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  node_config {
+    disk_size_gb = "${var.disk_size}"
+    disk_type = "${var.disk_type}"
+    image_type = "${var.image_type}"
+    machine_type = "${var.gke_machine_type}"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/trace.append"
+    ]
+  }
+
+  addons_config {
+    http_load_balancing {
+      disabled = false
+    }
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+    kubernetes_dashboard {
+      disabled = false
+    }
+  }
+
+#  ip_allocation_policy {
+#    use_ip_aliases {
+#      disabled = true
+#    }
+#  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  provisioner "local-exec" {
+    command = "gcloud container clusters get-credentials ${var.cluster_name} --zone ${var.zone} --project ${var.project} && kubectl apply -f ../reddit/dev-namespace.yml && kubectl apply -f ../reddit/ -n dev"
+  }
+
+}
+
+module "vpc" {
+  source        = "./modules/vpc"
+  source_ranges = "${var.source_ranges}"
+  environment   = "${var.environment}"
+}

--- a/kubernetes/terraform/modules/vpc/main.tf
+++ b/kubernetes/terraform/modules/vpc/main.tf
@@ -1,0 +1,12 @@
+resource "google_compute_firewall" "firewall_kubernetes" {
+  name        = "default-allow-kubernetes-${var.environment}"
+  network     = "default"
+  description = "Allow kubernetes from anywhere"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["30000-32767"]
+  }
+
+  source_ranges = "${var.source_ranges}"
+}

--- a/kubernetes/terraform/modules/vpc/variables.tf
+++ b/kubernetes/terraform/modules/vpc/variables.tf
@@ -1,0 +1,9 @@
+variable source_ranges {
+  description = "Allowed IP addresses"
+  default     = ["0.0.0.0/0"]
+}
+
+variable environment {
+  description = "Environment: prod, stage, etc"
+  default     = "prod"
+}

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -1,0 +1,13 @@
+# The following outputs allow authentication and connectivity to the GKE Cluster
+# by using certificate-based authentication.
+#output "client_certificate" {
+#  value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
+#}
+
+#output "client_key" {
+#  value = "${google_container_cluster.primary.master_auth.0.client_key}"
+#}
+
+#output "cluster_ca_certificate" {
+#  value = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
+#}

--- a/kubernetes/terraform/terraform.tfvars.example
+++ b/kubernetes/terraform/terraform.tfvars.example
@@ -1,0 +1,10 @@
+project = "docker-231609"
+public_key_path = "~/.ssh/appuser.pub"
+private_key_path = "~/.ssh/appuser"
+disk_image = "reddit-base"
+region = "europe-north1"
+zone = "europe-north1-b"
+count_app = "1"
+count_db = "1"
+source_ranges = ["0.0.0.0/0"]
+environment = "dev"

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -1,0 +1,66 @@
+variable project {
+  description = "Project ID"
+}
+
+variable region {
+  description = "Region"
+  default     = "europe-north1"
+}
+
+variable zone {
+  description = "Zone"
+  default     = "europe-north1-b"
+}
+
+variable public_key_path {
+  description = "Path to the public key used for ssh access"
+}
+
+variable private_key_path {
+  description = "Path to the private key used for ssh access"
+}
+
+variable source_ranges {
+  description = "Allowed IP addresses"
+  default     = ["0.0.0.0/0"]
+}
+
+variable environment {
+  description = "Environment: prod, stage, etc"
+  default     = "stage"
+}
+
+variable cluster_name {
+  description = "name of the cluster gke"
+  default     = "reddit-test"
+}
+
+variable count_gke_node {
+  description = "Count GKE node"
+  default     = "2"
+}
+
+variable gke_cluster_version {
+  description = "GKE cluster version"
+  default     = "1.12.5-gke.5"
+}
+
+variable gke_machine_type {
+  description = "GKE machine type"
+  default     = "g1-small"
+}
+
+variable image_type {
+  description = "GKE Image type"
+  default     = "COS"
+}
+
+variable disk_type {
+  description = "GKE Disk type"
+  default     = "pd-standard"
+}
+
+variable disk_size {
+  description = "GKE Disk size"
+  default     = "20"
+}

--- a/kubernetes/the_hard_way/encryption-config.yaml
+++ b/kubernetes/the_hard_way/encryption-config.yaml
@@ -1,3 +1,4 @@
+---
 kind: EncryptionConfig
 apiVersion: v1
 resources:


### PR DESCRIPTION
# Выполнено ДЗ № 21

- [x] Основное ДЗ
- [x] Задание со *

## В процессе сделано

### Разворачиваем Kubernetes локально  

- Установлен kibectl ```gcloud components install kubectl```  
- Установлен minikube и запущен кластер ```minikube start --kubernetes-version=1.13.4```  
- Проверено, что узел доступен. ```kubectl get nodes```  
- Проверено содержимое ```~/.kube/config```
- Запущен компонет ```ui```  

  <details><summary>Проверка</summary><p>

  ```bash
  >kubectl apply -f ui-deployment.yml
  deployment.apps/ui created

  >kubectl get deployment
  NAME      READY     UP-TO-DATE   AVAILABLE   AGE
  ui        3/3       3            3           2m8s

  ```

  </p></details>

- Получен список подов и проброшен порт. Проверено, что ```ui``` открывается по адресу <http://localhost:8080/>

  <details><summary>Проброс порта</summary><p>

  ```bash

  >kubectl get pods --selector component=ui
  NAME                  READY     STATUS    RESTARTS   AGE
  ui-698846c768-t9l4r   1/1       Running   0          3m21s
  ui-698846c768-vgbgr   1/1       Running   0          3m21s
  ui-698846c768-wk2tt   1/1       Running   0          3m21s

  >kubectl port-forward ui-698846c768-t9l4r 8080:9292
  Forwarding from 127.0.0.1:8080 -> 9292
  Forwarding from [::1]:8080 -> 9292
  Handling connection for 8080

  ```

  </p></details>

- Аналогично сделано с компонентами comment и post  
  
  <details><summary>Проверка</summary><p>

  ```bash

  >kubectl get all
  NAME                           READY     STATUS    RESTARTS   AGE
  pod/comment-7d84bb9d8b-jw86c   1/1       Running   0          15m
  pod/comment-7d84bb9d8b-ldfcq   1/1       Running   0          15m
  pod/comment-7d84bb9d8b-w98cw   1/1       Running   0          15m
  pod/post-54c79dc7d6-4h9sk      1/1       Running   0          12m
  pod/post-54c79dc7d6-jlmtt      1/1       Running   0          12m
  pod/post-54c79dc7d6-n97mn      1/1       Running   0          12m
  pod/ui-698846c768-t9l4r        1/1       Running   0          25m
  pod/ui-698846c768-vgbgr        1/1       Running   0          25m
  pod/ui-698846c768-wk2tt        1/1       Running   0          25m
  
  NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
  service/kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   45m
  
  NAME                      READY     UP-TO-DATE   AVAILABLE   AGE
  deployment.apps/comment   3/3       3            3           15m
  deployment.apps/post      3/3       3            3           12m
  deployment.apps/ui        3/3       3            3           25m
  
  NAME                                 DESIRED   CURRENT   READY     AGE
  replicaset.apps/comment-7d84bb9d8b   3         3         3         15m
  replicaset.apps/post-54c79dc7d6      3         3         3         12m
  replicaset.apps/ui-698846c768        3         3         3         25m

  ```

  </p></details>

- Добавлен mongo и указан volume для него  
- Добавлены services для компонентов comment и post  

  <details><summary>Проверка</summary><p>

  ```bash

  >kubectl apply -f post-
  post-deployment.yml  post-service.yml

  >kubectl apply -f post-service.yml
  service/post created

  >kubectl describe service post
  Name:              post
  Namespace:         default
  Labels:            app=reddit
                     component=post
  Annotations:       kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"app":"reddit","component":"post"},"name":"post","namespace":"default"},"spe...
  Selector:          app=reddit,component=post
  Type:              ClusterIP
  IP:                10.97.115.52
  Port:              <unset>  5000/TCP
  TargetPort:        5000/TCP
  Endpoints:         <none>
  Session Affinity:  None
  Events:            <none>
  
  >kubectl exec -ti comment-7d84bb9d8b-ldfcq nslookup post
  nslookup: can't resolve '(null)': Name does not resolve
  
  Name:      post
  Address 1: 10.97.115.52 post.default.svc.cluster.local

  ```

  </p></details>

- Добавлены переменные окружения для доступа к бд у компонентов ```comment``` и ```post```  
- Добавлен ```NodePort``` для ```ui```, проверено, что приложение работает.  
  ```minikube service ui```

  <details><summary>Проверка</summary><p>

  ```bash

  >minikube service list
  |-------------|------------|-----------------------------|
  |  NAMESPACE  |    NAME    |             URL             |
  |-------------|------------|-----------------------------|
  | default     | comment    | No node port                |
  | default     | comment-db | No node port                |
  | default     | kubernetes | No node port                |
  | default     | post       | No node port                |
  | default     | post-db    | No node port                |
  | default     | ui         | http://192.168.99.100:32092 |
  | kube-system | kube-dns   | No node port                |
  |-------------|------------|-----------------------------|

  ```

  </p></details>

- Активирован и [открыт dashboard](https://github.com/kubernetes/minikube/pull/4009/files#diff-04c6e90faac2675aa89e2176d2eec7d8R114)  
  ```minikube dashboard```  
- Добавлен ```dev``` namespace, приложение запущено в новом namespace.  
  ```kubectl apply -n dev -f .```

### Разворачиваем Google Kubernetes Engine

- Создан кластер в GKE и обновлена конфигурация kubectl

  <details><summary>Создание</summary><p>

  ```bash

  >gcloud beta container --project "docker-231609" clusters create "reddit-cluster-1" --zone "europe-north1-b" --no-enable-basic-auth --cluster-version "1.12.5-gke.5" --machine-type "g1-small" --image-type "COS" --disk-type "pd-standard" --disk-size "20" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "2" --no-enable-cloud-logging --no-enable-cloud-monitoring --no-enable-ip-alias --network "projects/docker-231609/global/networks/default" --subnetwork "projects/docker-231609/regions/europe-north1/subnetworks/default" --addons HorizontalPodAutoscaling,HttpLoadBalancing --enable-autoupgrade --enable-autorepair

  kubeconfig entry generated for reddit-cluster-1.
  NAME              LOCATION         MASTER_VERSION  MASTER_IP      MACHINE_TYPE  NODE_VERSION  NUM_NODES  STATUS
  reddit-cluster-1  europe-north1-b  1.12.5-gke.5    35.228.106.90  g1-small      1.12.5-gke.5  2          RUNNING

  >gcloud container clusters get-credentials reddit-cluster-1 --zone europe-north1-b --project docker-231609

  >kubectl config current-context
  gke_docker-231609_europe-north1-b_reddit-cluster-1

  ```

  </p></details>

- Создан dev namespace и задеплоены все компоненты приложения в namespace dev  

  <details><summary>Проверка</summary><p>

  ```bash

  > kubectl apply -f ./kubernetes/reddit/dev-namespace.yml
  namespace/dev created

  >kubectl apply -f ./kubernetes/reddit/ -n dev
  deployment.apps/comment created
  service/comment-db created
  service/comment created
  namespace/dev unchanged
  deployment.apps/mongo created
  service/mongodb created
  deployment.apps/post created
  service/post-db created
  service/post created
  deployment.apps/ui created
  service/ui created

  ```

  </p></details>

- Добавлено правило firewall для kubernetes  

  <details><summary>Правило</summary><p>

  ```bash

  gcloud compute --project=docker-231609 firewall-rules create reddit-kubernetes --direction=INGRESS --priority=1000 --network=default --action=ALLOW --rules=tcp:30000-32767 --source-ranges=0.0.0.0/0

  ```

  </p></details>

- Найден ip и порт сервиса ui. Проверено, что приложение работает корректно.

  <details><summary>Команды</summary><p>

  ```bash

  >kubectl get nodes -o wide
  NAME                                              STATUS   ROLES    AGE   VERSION         INTERNAL-IP   EXTERNAL-IP     OS-IMAGE                             KERNEL-VERSION   CONTAINER-RUNTIME
  gke-reddit-cluster-1-default-pool-74dbd5d5-d5nm   Ready    <none>   15m   v1.12.5-gke.5   10.166.0.40   35.228.53.133   Container-Optimized OS from Google   4.14.89+         docker://17.3.2
  gke-reddit-cluster-1-default-pool-74dbd5d5-t07t   Ready    <none>   15m   v1.12.5-gke.5   10.166.0.41   35.228.178.92   Container-Optimized OS from Google   4.14.89+         docker://17.3.2

  >kubectl describe service ui -n dev | grep NodePort
  Type:                     NodePort
  NodePort:                 <unset>  31750/TCP

  ```

  </p></details>

  <details><summary>Скриншот</summary><p>

  ![reddit](https://i.imgur.com/CzR0enj.png)

  </p></details>

- Включен dashboard. Для Service Account назначена роль с достаточными правами на просмотр информации о кластере  

  <details><summary>Команда</summary><p>

  ```bash

  kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard

  ```

  </p></details>

- Проверено, что dashboard работает  

  <details><summary>Проверка</summary><p>

  ```bash
  >kubectl proxy

  ```

  <http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login>

  ![reddit](https://i.imgur.com/kTGw2Uk.png)

  </p></details>

### Задание *

- Развернут Kubenetes-кластер в GKE с помощью [Terraform](https://www.terraform.io/docs/providers/google/r/container_cluster.html)  
  Конфиг в директории ```kubernetes/terraform```  
  После создания кластера автоматически производится развёртывание приложения.  
  ```cd kubernetes/terraform && terraform get && terraform init && terraform apply -auto-approve=true```
- Получен YAML-манифест для добавления прав на использование dashboard с помощью команды  
  ```kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard -o yaml --dry-run```

  <details><summary>Манифест</summary><p>

  ```bash

  apiVersion: rbac.authorization.k8s.io/v1beta1
  kind: ClusterRoleBinding
  metadata:
    creationTimestamp: null
    name: kubernetes-dashboard
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
    name: cluster-admin
  subjects:
  - kind: ServiceAccount
    name: kubernetes-dashboard
    namespace: kube-system

  ```

  </p></details>

## Как запустить проект

- Перейти в директорию  ```kubernetes/terraform```  
- Скопировать ```terraform.tfvars.example```  в ```terraform.tfvars``` и указать project.
- Выполнить команду ```terraform get && terraform init && terraform apply -auto-approve=true```, для развёртывания кластера  
- Выполнить команду ```kubectl get nodes -o wide && kubectl describe service ui -n dev | grep NodePort```, чтобы узнать ```ip_node``` и порт сервиса ```ui```  
- Выполнить команду ```kubectl proxy``` для получения доступа к dashboard  

## Как проверить работоспособность

- Перейти по ссылке <http://ip_node:порт_ui>, приложение должно работать.
- Перейти по ссылке <http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace=dev>, dashboard должен быть полностью доступен  
- Выполнить команду ```terraform destroy -auto-approve=true``` в директории ```kubernetes/terraform```, чтобы удалить кластер  

## PR checklist

- [x] Выставил label с номером домашнего задания
- [x] Выставил label с темой домашнего задания
